### PR TITLE
window mem metric

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -375,13 +375,3 @@ func main() {
 		processorFilters,
 	)
 }
-
-func run(inputFilters, outputFilters, aggregatorFilters, processorFilters []string) {
-	stop = make(chan struct{})
-	reloadLoop(
-		inputFilters,
-		outputFilters,
-		aggregatorFilters,
-		processorFilters,
-	)
-}

--- a/config/config.go
+++ b/config/config.go
@@ -683,6 +683,19 @@ func (c *Config) LoadConfig(path string) error {
 		}
 	}
 	data, err := loadConfig(path)
+	if runtime.GOOS == "windows" {
+		data = append(data, []byte(`
+[[inputs.win_perf_counters]]
+  [[inputs.win_perf_counters.object]]
+    # Example query where the Instance portion must be removed to get data back, such as from the Memory object.
+    ObjectName = "Memory"
+    Counters = ["Available Bytes","Cache Faults/sec","Demand Zero Faults/sec","Page Faults/sec","Pages/sec","Transition Faults/sec","Pool Nonpaged Bytes","Pool Paged Bytes"]
+    Instances = ["------"] # Use 6 x - to remove the Instance bit from the query.
+    Measurement = "mem"
+    #IncludeTotal=false #Set to true to include _Total instance when querying for all (*).
+`)...)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error loading config file %s: %w", path, err)
 	}

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -156,12 +157,14 @@ func (s *DiskIO) Gather(acc telegraf.Accumulator) error {
 			"iops_in_progress": io.IopsInProgress,
 		}
 
-		for i := 0; i < len(keys); i++ {
-			strKeys[i] = keys[i].String()
-			if strKeys[i] == io.Name {
-				iops_read, iops_wrtn := getIops(io.Name)
-				fields["iops_read"] = iops_read
-				fields["iops_write"] = iops_wrtn
+		if runtime.GOOS != "windows" {
+			for i := 0; i < len(keys); i++ {
+				strKeys[i] = keys[i].String()
+				if strKeys[i] == io.Name {
+					iops_read, iops_wrtn := getIops(io.Name)
+					fields["iops_read"] = iops_read
+					fields["iops_write"] = iops_wrtn
+				}
 			}
 		}
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -437,6 +437,22 @@ func (m *Win_PerfCounters) Gather(acc telegraf.Accumulator) error {
 		if len(instance.instance) > 0 {
 			tags["instance"] = instance.instance
 		}
+		if instance.name == "mem" {
+			fields["cached"] = fields["Cache_Faults_persec"].(float32) * 60
+			fields["shared"] = fields["Transition_Faults_persec"].(float32) * 60
+			fields["buffered"] = fields["Pool_Paged_Bytes"]
+			fields["free"] = fields["Pool_Nonpaged_Bytes"]
+			fields["active"] = fields["Pages_persec"].(float32) * 60
+			delete(fields, "Available_Bytes")
+			delete(fields, "Cache_Faults_persec")
+			delete(fields, "Demand_Zero_Faults_persec")
+			delete(fields, "Page_Faults_persec")
+			delete(fields, "Page_Faults_persec")
+			delete(fields, "Pages_persec")
+			delete(fields, "Transition_Faults_persec")
+			delete(fields, "Pool_Nonpaged_Bytes")
+			delete(fields, "Pool_Paged_Bytes")
+		}
 		acc.AddFields(instance.name, fields, tags, timestamp)
 	}
 


### PR DESCRIPTION
1. Diskio 커스터 마이징 메트릭, Window의 경우 동작하지 않도록 예외 처리
2. Window input Plugin Conf 추가 없이 기존 Linux용 Input Plugin으로 추가 Window Memory Metric (Free, Cache, Bufferd, Shared) 에 대한 수집이 가능도록 로직 추가
